### PR TITLE
docs(management-rules.md): fix typo (again.)

### DIFF
--- a/doc/management-rules.md
+++ b/doc/management-rules.md
@@ -7,7 +7,7 @@
 - **RG3:** Un utilisateur possède une **adresse mail**.
 - **RG4:** Un utilisateur possède un mot de passe.
 - **RG5:** Un utilisateur peut être un **admin** ou un **collaborateur**.
-- **RG6:** Un utilisateur non-authentifié est considéré comme un **visteur**.
+- **RG6:** Un utilisateur non-authentifié est considéré comme un **visiteur**.
 - **RG7:** Un admin peut créer un compte **collaborateur**.
 - **RG8:** Un admin peut modifier un compte **collaborateur**.
 - **RG9:** Un admin peut supprimer un compte **collaborateur**.


### PR DESCRIPTION
Fix 'visteur' into 'visiteur' at line 10